### PR TITLE
feat: add CI/CD pipeline for ICP canister deployment

### DIFF
--- a/.github/workflows/deploy-icp-canister.yml
+++ b/.github/workflows/deploy-icp-canister.yml
@@ -3,8 +3,8 @@ name: Deploy ICP Canister
 on:
   push:
     tags:
-      - "v*.*.*" # Triggers on version tags like v1.0.0, v1.2.3
-  workflow_dispatch: # Allows manual deployment from GitHub UI
+      - "v*.*.*"
+  workflow_dispatch:
     inputs:
       environment:
         description: "Environment to deploy to"
@@ -14,14 +14,20 @@ on:
         options:
           - mainnet
           - local
+      cycles_amount:
+        description: "Cycles (in trillions)"
+        required: false
+        default: "1.0"
+        type: string
 
 env:
   DFX_VERSION: "0.28.0"
   RUST_VERSION: "1.89.0"
+  DFX_NETWORK: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'local' && 'local' || 'ic' }}
 
 jobs:
-  build-and-test:
-    name: Build and Test Canister
+  build-and-deploy:
+    name: Build and Deploy
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -31,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Rust
+      - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -40,7 +46,7 @@ jobs:
           override: true
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -49,121 +55,52 @@ jobs:
             ~/.cargo/git/db/
             ./merodocs_registry/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
 
-      - name: Install candid-extractor
-        run: cargo install candid-extractor --version 0.1.4
-
-      - name: Install dfx
+      - name: Install tools
         run: |
-          wget https://github.com/dfinity/sdk/releases/download/${{ env.DFX_VERSION }}/dfx-${{ env.DFX_VERSION }}-x86_64-linux.tar.gz
-          tar -xzf dfx-${{ env.DFX_VERSION }}-x86_64-linux.tar.gz
-          sudo mv dfx /usr/local/bin/dfx
-          dfx --version
-
-      - name: Build canister
-        run: |
-          dfx start --background --clean
-          dfx build
-          dfx stop
-
-      - name: Run basic tests
-        run: |
-          # Build the canister to ensure it compiles correctly
-          cargo build --target wasm32-unknown-unknown --release -p backend
-
-          # Verify the WASM file was created
-          ls -la target/wasm32-unknown-unknown/release/backend.wasm
-
-          # Extract and verify Candid interface
-          candid-extractor target/wasm32-unknown-unknown/release/backend.wasm > backend/backend.did
-          echo "✅ Canister built and Candid interface extracted successfully"
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: canister-build
-          path: |
-            ./merodocs_registry/target/wasm32-unknown-unknown/release/backend.wasm
-            ./merodocs_registry/backend/backend.did
-
-  deploy:
-    name: Deploy to ICP Mainnet
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
-    defaults:
-      run:
-        working-directory: ./merodocs_registry
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: canister-build
-          path: ./merodocs_registry/
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_VERSION }}
-          target: wasm32-unknown-unknown
-          override: true
-
-      - name: Install candid-extractor
-        run: cargo install candid-extractor --version 0.1.4
-
-      - name: Install dfx
-        run: |
-          wget https://github.com/dfinity/sdk/releases/download/${{ env.DFX_VERSION }}/dfx-${{ env.DFX_VERSION }}-x86_64-linux.tar.gz
-          tar -xzf dfx-${{ env.DFX_VERSION }}-x86_64-linux.tar.gz
-          sudo mv dfx /usr/local/bin/dfx
-          dfx --version
+          cargo install candid-extractor --version 0.1.4
+          sh -ci "$(curl -fsSL https://internetcomputer.org/install.sh)" -- --version ${{ env.DFX_VERSION }}
+          echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Setup dfx identity
+        if: env.DFX_NETWORK == 'ic'
         run: |
           echo "${{ secrets.DFX_IDENTITY_PEM }}" > identity.pem
+          if dfx identity list | grep -q "deployment"; then
+            dfx identity remove deployment
+          fi
           dfx identity import deployment identity.pem
           dfx identity use deployment
           rm identity.pem
-          echo "✅ Identity configured"
 
-      - name: Deploy to ICP Mainnet
+      - name: Start local dfx
+        if: env.DFX_NETWORK == 'local'
+        run: dfx start --background --clean
+
+      - name: Build canister
         run: |
-          # Install npm dependencies if package.json exists (as per BUILD.md step 4)
-          if [ -f "package.json" ]; then
-            echo "📦 Installing npm dependencies..."
-            npm install
+          dfx build
+          cargo build --target wasm32-unknown-unknown --release -p backend
+          candid-extractor target/wasm32-unknown-unknown/release/backend.wasm > backend/backend.did
+
+      - name: Deploy canister
+        run: |
+          if [ "${{ env.DFX_NETWORK }}" = "ic" ]; then
+            CYCLES=$(echo "${{ github.event.inputs.cycles_amount || '1.0' }} * 1000000000000" | bc -l | cut -d. -f1)
+            dfx deploy --network ic --with-cycles $CYCLES
+          else
+            dfx deploy
           fi
 
-          # Deploy to mainnet (as per BUILD.md step 6)
-          echo "🚀 Deploying to ICP mainnet with cycles..."
-          dfx deploy --network ic --with-cycles 1000000000000
-
-          echo "✅ Deployment completed successfully!"
-
-          # Show canister info and cycles status
-          echo "📊 Canister information:"
-          dfx canister --network ic info backend
-
-          # Check cycles balance (important for ongoing operations)
-          echo "💰 Cycles status:"
-          dfx canister --network ic status backend --with-cycles || echo "Note: Cycles status check failed (this is normal for new deployments)"
-
-      - name: Create deployment summary
+      - name: Get canister info
         run: |
-          echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Network:** ICP Mainnet" >> $GITHUB_STEP_SUMMARY
-          echo "**Canister:** backend" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Canister URLs:" >> $GITHUB_STEP_SUMMARY
-          CANISTER_ID=$(dfx canister --network ic id backend)
-          echo "- **Backend:** https://${CANISTER_ID}.icp0.io" >> $GITHUB_STEP_SUMMARY
-          echo "- **Candid UI:** https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=${CANISTER_ID}" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ env.DFX_NETWORK }}" = "ic" ]; then
+            CANISTER_ID=$(dfx canister --network ic id backend)
+            echo "**Canister ID**: $CANISTER_ID" >> $GITHUB_STEP_SUMMARY
+            echo "**URL**: https://${CANISTER_ID}.icp0.io" >> $GITHUB_STEP_SUMMARY
+          else
+            CANISTER_ID=$(dfx canister id backend)
+            echo "**Canister ID**: $CANISTER_ID" >> $GITHUB_STEP_SUMMARY
+            echo "**URL**: http://localhost:4943/?canisterId=$CANISTER_ID" >> $GITHUB_STEP_SUMMARY
+            dfx stop
+          fi

--- a/.github/workflows/deploy-icp-canister.yml
+++ b/.github/workflows/deploy-icp-canister.yml
@@ -1,0 +1,169 @@
+name: Deploy ICP Canister
+
+on:
+  push:
+    tags:
+      - "v*.*.*" # Triggers on version tags like v1.0.0, v1.2.3
+  workflow_dispatch: # Allows manual deployment from GitHub UI
+    inputs:
+      environment:
+        description: "Environment to deploy to"
+        required: true
+        default: "mainnet"
+        type: choice
+        options:
+          - mainnet
+          - local
+
+env:
+  DFX_VERSION: "0.28.0"
+  RUST_VERSION: "1.89.0"
+
+jobs:
+  build-and-test:
+    name: Build and Test Canister
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./merodocs_registry
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./merodocs_registry/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install candid-extractor
+        run: cargo install candid-extractor --version 0.1.4
+
+      - name: Install dfx
+        run: |
+          wget https://github.com/dfinity/sdk/releases/download/${{ env.DFX_VERSION }}/dfx-${{ env.DFX_VERSION }}-x86_64-linux.tar.gz
+          tar -xzf dfx-${{ env.DFX_VERSION }}-x86_64-linux.tar.gz
+          sudo mv dfx /usr/local/bin/dfx
+          dfx --version
+
+      - name: Build canister
+        run: |
+          dfx start --background --clean
+          dfx build
+          dfx stop
+
+      - name: Run basic tests
+        run: |
+          # Build the canister to ensure it compiles correctly
+          cargo build --target wasm32-unknown-unknown --release -p backend
+
+          # Verify the WASM file was created
+          ls -la target/wasm32-unknown-unknown/release/backend.wasm
+
+          # Extract and verify Candid interface
+          candid-extractor target/wasm32-unknown-unknown/release/backend.wasm > backend/backend.did
+          echo "✅ Canister built and Candid interface extracted successfully"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: canister-build
+          path: |
+            ./merodocs_registry/target/wasm32-unknown-unknown/release/backend.wasm
+            ./merodocs_registry/backend/backend.did
+
+  deploy:
+    name: Deploy to ICP Mainnet
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    defaults:
+      run:
+        working-directory: ./merodocs_registry
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: canister-build
+          path: ./merodocs_registry/
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Install candid-extractor
+        run: cargo install candid-extractor --version 0.1.4
+
+      - name: Install dfx
+        run: |
+          wget https://github.com/dfinity/sdk/releases/download/${{ env.DFX_VERSION }}/dfx-${{ env.DFX_VERSION }}-x86_64-linux.tar.gz
+          tar -xzf dfx-${{ env.DFX_VERSION }}-x86_64-linux.tar.gz
+          sudo mv dfx /usr/local/bin/dfx
+          dfx --version
+
+      - name: Setup dfx identity
+        run: |
+          echo "${{ secrets.DFX_IDENTITY_PEM }}" > identity.pem
+          dfx identity import deployment identity.pem
+          dfx identity use deployment
+          rm identity.pem
+          echo "✅ Identity configured"
+
+      - name: Deploy to ICP Mainnet
+        run: |
+          # Install npm dependencies if package.json exists (as per BUILD.md step 4)
+          if [ -f "package.json" ]; then
+            echo "📦 Installing npm dependencies..."
+            npm install
+          fi
+
+          # Deploy to mainnet (as per BUILD.md step 6)
+          echo "🚀 Deploying to ICP mainnet with cycles..."
+          dfx deploy --network ic --with-cycles 1000000000000
+
+          echo "✅ Deployment completed successfully!"
+
+          # Show canister info and cycles status
+          echo "📊 Canister information:"
+          dfx canister --network ic info backend
+
+          # Check cycles balance (important for ongoing operations)
+          echo "💰 Cycles status:"
+          dfx canister --network ic status backend --with-cycles || echo "Note: Cycles status check failed (this is normal for new deployments)"
+
+      - name: Create deployment summary
+        run: |
+          echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Network:** ICP Mainnet" >> $GITHUB_STEP_SUMMARY
+          echo "**Canister:** backend" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Canister URLs:" >> $GITHUB_STEP_SUMMARY
+          CANISTER_ID=$(dfx canister --network ic id backend)
+          echo "- **Backend:** https://${CANISTER_ID}.icp0.io" >> $GITHUB_STEP_SUMMARY
+          echo "- **Candid UI:** https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=${CANISTER_ID}" >> $GITHUB_STEP_SUMMARY

--- a/merodocs_registry/.gitignore
+++ b/merodocs_registry/.gitignore
@@ -1,0 +1,5 @@
+# dfx build artifacts
+.dfx/
+target/
+dist/
+node_modules/

--- a/merodocs_registry/CI-CD-SETUP.md
+++ b/merodocs_registry/CI-CD-SETUP.md
@@ -1,0 +1,193 @@
+# CI/CD Pipeline Setup for MeroDocs ICP Canister
+
+This document explains how to set up and use the CI/CD pipeline for deploying your ICP canister to the mainnet.
+
+## 🚀 Pipeline Overview
+
+### **Deployment Triggers**
+
+- **Automatic**: Push git tags following semver pattern (e.g., `v1.0.0`, `v2.1.3`)
+- **Manual**: Using GitHub Actions "Run workflow" button
+
+### **Release Process**
+
+A new version is released by creating and pushing a git tag:
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+### **Testing Strategy**
+
+Before deployment, the pipeline:
+
+1. ✅ Builds the Rust canister for WASM32 target
+2. ✅ Verifies WASM file generation
+3. ✅ Extracts and validates Candid interface
+4. ✅ Runs compilation tests
+
+## 🔧 Setup Instructions
+
+### 1. Generate DFX Identity for CI/CD
+
+First, create a new identity specifically for deployments:
+
+```bash
+# Create a new identity
+dfx identity new ci-deployment
+dfx identity use ci-deployment
+
+# Get the principal ID (you'll need this for cycles management)
+dfx identity get-principal
+
+# Export the identity to PEM format
+dfx identity export ci-deployment > ci-identity.pem
+```
+
+### 2. Configure GitHub Secrets
+
+Go to your GitHub repository → Settings → Secrets and Variables → Actions, and add:
+
+#### Required Secrets:
+
+- **`DFX_IDENTITY_PEM`**: Contents of the `ci-identity.pem` file you generated
+
+#### Optional Secrets (for future enhancements):
+
+- **`CYCLES_WALLET_ID`**: Your cycles wallet canister ID
+- **`SLACK_WEBHOOK_URL`**: For deployment notifications
+
+### 3. Fund Your Deployment Identity
+
+Your deployment identity needs cycles to create and manage canisters:
+
+```bash
+# Switch to your funded identity
+dfx identity use default  # or your main identity
+
+# Transfer ICP to the deployment identity
+dfx ledger transfer --amount 0.5 --to $(dfx identity get-principal ci-deployment)
+
+# Convert ICP to cycles (using deployment identity)
+dfx identity use ci-deployment
+dfx cycles convert --amount 0.4
+```
+
+## 📋 Usage
+
+### Creating a Release
+
+1. **Make your changes** and commit them to your branch
+2. **Merge to main/master** branch
+3. **Create and push a version tag**:
+   ```bash
+   git checkout master
+   git pull origin master
+   git tag v1.0.0  # Use semantic versioning
+   git push origin v1.0.0
+   ```
+
+The pipeline will automatically:
+
+- Build and test the canister
+- Deploy to ICP mainnet
+- Provide deployment URLs in the GitHub Actions summary
+
+### Manual Deployment
+
+You can also trigger deployments manually:
+
+1. Go to GitHub → Actions tab
+2. Select "Deploy ICP Canister" workflow
+3. Click "Run workflow"
+4. Choose environment and run
+
+### Testing Before Release
+
+Before creating a release tag, test locally:
+
+```bash
+cd merodocs_registry
+./test-deployment.sh
+```
+
+This script will:
+
+- Check prerequisites
+- Build the canister locally
+- Deploy to local dfx instance
+- Provide testing URLs
+
+## 📊 Pipeline Workflow
+
+```mermaid
+graph TD
+    A[Push Tag v*.*.*] --> B[Build & Test Job]
+    B --> C{Tests Pass?}
+    C -->|Yes| D[Deploy Job]
+    C -->|No| E[❌ Fail Pipeline]
+    D --> F[Setup dfx Identity]
+    F --> G[Deploy to ICP Mainnet]
+    G --> H[✅ Success - Post URLs]
+
+    I[Manual Trigger] --> D
+```
+
+## 🔍 Monitoring Deployments
+
+After deployment, you can monitor your canister:
+
+### Canister URLs:
+
+- **Main Interface**: `https://{CANISTER_ID}.icp0.io`
+- **Candid UI**: `https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id={CANISTER_ID}`
+
+### Useful dfx Commands:
+
+```bash
+# Check canister status
+dfx canister --network ic status backend
+
+# View canister info
+dfx canister --network ic info backend
+
+# Check cycles balance
+dfx canister --network ic status backend --with-cycles
+```
+
+## 🛠 Troubleshooting
+
+### Common Issues:
+
+**Pipeline fails with "insufficient cycles":**
+
+- Fund your deployment identity with more ICP/cycles
+- Check cycles balance: `dfx wallet --network ic balance`
+
+**Build fails:**
+
+- Check Rust version compatibility
+- Ensure all dependencies are specified in Cargo.toml
+- Test locally with `./test-deployment.sh`
+
+**Identity issues:**
+
+- Regenerate the identity PEM and update the secret
+- Ensure the identity has sufficient cycles
+
+### Getting Help:
+
+1. Check the GitHub Actions logs for detailed error messages
+2. Test the deployment locally first
+3. Verify your dfx and Rust versions match the pipeline
+
+## 📈 Next Steps
+
+Consider these enhancements:
+
+- Add automated tests for canister functionality
+- Set up monitoring and alerting
+- Implement staging environment
+- Add rollback capabilities
+- Set up automatic cycles top-up

--- a/merodocs_registry/release.sh
+++ b/merodocs_registry/release.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Version management script for MeroDocs
+# Usage: ./release.sh [major|minor|patch]
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Check if we're on the right branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "master" ] && [ "$CURRENT_BRANCH" != "main" ]; then
+    echo -e "${RED}❌ Please run this script from master/main branch${NC}"
+    echo "Current branch: $CURRENT_BRANCH"
+    exit 1
+fi
+
+# Check for uncommitted changes
+if [[ -n $(git status --porcelain) ]]; then
+    echo -e "${RED}❌ You have uncommitted changes. Please commit or stash them first.${NC}"
+    git status --short
+    exit 1
+fi
+
+# Get current version from git tags
+CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+echo -e "${YELLOW}Current version: $CURRENT_VERSION${NC}"
+
+# Parse current version
+CURRENT_VERSION_CLEAN=${CURRENT_VERSION#v}  # Remove 'v' prefix
+IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION_CLEAN"
+MAJOR=${VERSION_PARTS[0]:-0}
+MINOR=${VERSION_PARTS[1]:-0}
+PATCH=${VERSION_PARTS[2]:-0}
+
+# Determine new version
+RELEASE_TYPE=${1:-patch}
+
+case $RELEASE_TYPE in
+    major)
+        NEW_MAJOR=$((MAJOR + 1))
+        NEW_MINOR=0
+        NEW_PATCH=0
+        ;;
+    minor)
+        NEW_MAJOR=$MAJOR
+        NEW_MINOR=$((MINOR + 1))
+        NEW_PATCH=0
+        ;;
+    patch)
+        NEW_MAJOR=$MAJOR
+        NEW_MINOR=$MINOR
+        NEW_PATCH=$((PATCH + 1))
+        ;;
+    *)
+        echo -e "${RED}❌ Invalid release type: $RELEASE_TYPE${NC}"
+        echo "Usage: $0 [major|minor|patch]"
+        exit 1
+        ;;
+esac
+
+NEW_VERSION="v${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+
+echo -e "${YELLOW}New version will be: $NEW_VERSION${NC}"
+echo ""
+
+# Confirmation
+read -p "Do you want to create and push tag $NEW_VERSION? (y/N): " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "❌ Release cancelled"
+    exit 1
+fi
+
+# Update version in Cargo.toml if it exists
+if [ -f "backend/Cargo.toml" ]; then
+    echo -e "${YELLOW}Updating version in backend/Cargo.toml...${NC}"
+    sed -i.bak "s/^version = .*/version = \"${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}\"/" backend/Cargo.toml
+    rm backend/Cargo.toml.bak
+    git add backend/Cargo.toml
+    git commit -m "chore: bump version to ${NEW_VERSION}" || echo "No changes to commit"
+fi
+
+# Create and push tag
+echo -e "${YELLOW}Creating and pushing tag...${NC}"
+git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+git push origin "$NEW_VERSION"
+
+echo ""
+echo -e "${GREEN}🎉 Successfully created and pushed tag: $NEW_VERSION${NC}"
+echo ""
+echo "The CI/CD pipeline will automatically deploy this version to ICP mainnet."
+echo "You can monitor the deployment at:"
+echo "https://github.com/$(git config --get remote.origin.url | sed 's/.*github.com[:/]\(.*\)\.git/\1/')/actions"

--- a/merodocs_registry/test-deployment.sh
+++ b/merodocs_registry/test-deployment.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Local deployment test script for MeroDocs ICP Canister
+# This script simulates what the CI/CD pipeline does locally
+
+set -e
+
+echo "🧪 Testing MeroDocs ICP Canister Deployment Pipeline"
+echo "=================================================="
+
+cd "$(dirname "$0")"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "📍 Current directory: $(pwd)"
+
+# Check prerequisites
+echo -e "${YELLOW}Checking prerequisites...${NC}"
+
+if ! command -v dfx &> /dev/null; then
+    echo -e "${RED}❌ dfx not found. Please install dfx first.${NC}"
+    exit 1
+fi
+
+if ! command -v cargo &> /dev/null; then
+    echo -e "${RED}❌ cargo not found. Please install Rust first.${NC}"
+    exit 1
+fi
+
+if ! command -v candid-extractor &> /dev/null; then
+    echo -e "${YELLOW}Installing candid-extractor...${NC}"
+    cargo install candid-extractor
+fi
+
+echo -e "${GREEN}✅ Prerequisites check passed${NC}"
+
+# We're already in merodocs_registry directory, so no need to cd again
+
+# Start dfx (or use existing instance)
+echo -e "${YELLOW}Checking dfx status...${NC}"
+if dfx ping > /dev/null 2>&1; then
+    echo -e "${GREEN}✅ dfx is already running${NC}"
+else
+    echo -e "${YELLOW}Starting dfx...${NC}"
+    dfx start --background --clean
+fi
+
+# Create canister (if it doesn't exist)
+echo -e "${YELLOW}Creating canister (if needed)...${NC}"
+if ! dfx canister id backend > /dev/null 2>&1; then
+    echo -e "${YELLOW}Creating backend canister...${NC}"
+    dfx canister create backend
+else
+    echo -e "${GREEN}✅ Backend canister already exists${NC}"
+fi
+
+# Build canister
+echo -e "${YELLOW}Building canister...${NC}"
+dfx build
+
+# Deploy locally
+echo -e "${YELLOW}Deploying canister locally...${NC}"
+dfx deploy
+
+# Get canister info
+echo -e "${YELLOW}Getting canister information...${NC}"
+BACKEND_ID=$(dfx canister id backend)
+
+echo ""
+echo -e "${GREEN}🎉 Local deployment successful!${NC}"
+echo "================================"
+echo "Backend Canister ID: $BACKEND_ID"
+echo "Local Candid UI: http://127.0.0.1:4943/?canisterId=$(dfx canister id __Candid_UI)&id=$BACKEND_ID"
+echo ""
+echo "To test the canister, you can:"
+echo "1. Visit the Candid UI URL above"
+echo "2. Run: dfx canister call backend <method_name>"
+echo ""
+echo -e "${YELLOW}To stop the local dfx instance: dfx stop${NC}"


### PR DESCRIPTION
- Add GitHub Actions workflow for automated deployment
- Add setup documentation and testing guide
- Add version management and local testing scripts
- Add gitignore for build artifacts

Pipeline features:
- Triggers on version tags (v*.*.*) and manual dispatch
- Builds and tests canister before deployment
- Deploys to ICP mainnet with cycles management
- Provides deployment URLs and monitoring info